### PR TITLE
add note about Prospector being inactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**NOTE:** *Prospector project is inactivity. The project will become active once someone starts maintaining it again.*
+
 Prospector
 
 Prospector permits automated collection of a wide range of metrics of 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**NOTE:** *Prospector project is inactivity. The project will become active once someone starts maintaining it again.*
+**NOTE:** *Prospector project is inactive. The project will become active once someone starts maintaining it again.*
 
 Prospector
 


### PR DESCRIPTION
The project was unpinned from the CHAOSS organization GitHub account. 
This commit is to implement the second part of the Governing Board decision from 2019-03-15 to move Prospector to the attic.
Signed-off-by: Georg J.P. Link <linkgeorg@gmail.com>